### PR TITLE
Relocate Common Dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -121,6 +121,11 @@ tasks {
       exclude(dependency("org.jetbrains.kotlinx:kotlinx-coroutines-.*"))
       exclude(dependency("org.slf4j:.*"))
     }
+    relocate("com.typesafe.config", "littlechasiu.ctm.com.typesafe.config")
+    relocate("org.fusesource.jansi", "littlechasiu.ctm.org.fusesource.jansi")
+
+
+
     configurations = listOf(shadowDep)
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
   }


### PR DESCRIPTION
This PR fixes #57, #40 and #20 by relocating common dependencies to their own namespace, thus avoiding `java.lang.module.ResolutionException`.