### PR TITLE
Update Forge version to Create 6

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,6 +17,7 @@ val minecraft_version: String by project
 val maven_group: String by project
 val archives_base_name: String by project
 val create_version_short: String by project
+val ponder_version: String by project
 
 version = mod_version
 group = maven_group
@@ -33,6 +34,8 @@ repositories {
   maven("https://thedarkcolour.github.io/KotlinForForge/")
   maven("https://maven.blamejared.com/")  // JEI
   maven("https://squiddev.cc/maven/")  // CC: Tweaked
+  maven("https://maven.createmod.net")  // Ponder (Catnip)
+  maven("https://raw.githubusercontent.com/Fuzss/modresources/main/maven/")  // Forge Config Api Port
 }
 
 val shadowDep: Configuration by configurations.creating
@@ -55,6 +58,7 @@ dependencies {
   minecraft("net.neoforged:forge:${minecraft_version}-${forge_version}")
   implementation("thedarkcolour:kotlinforforge:$forge_kotlin_version")
   implementation(fg.deobf("com.simibubi.create:create-${minecraft_version}:${create_version}:slim"))
+  implementation("net.createmod.ponder:Ponder-Forge-${minecraft_version}:${ponder_version}")
 
   shadowDep("io.ktor:ktor-server-core-jvm:$ktor_version")
   shadowDep("io.ktor:ktor-server-cio-jvm:$ktor_version")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,7 +35,6 @@ repositories {
   maven("https://maven.blamejared.com/")  // JEI
   maven("https://squiddev.cc/maven/")  // CC: Tweaked
   maven("https://maven.createmod.net")  // Ponder (Catnip)
-  maven("https://raw.githubusercontent.com/Fuzss/modresources/main/maven/")  // Forge Config Api Port
 }
 
 val shadowDep: Configuration by configurations.creating

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,8 +11,9 @@ minecraft_version = 1.20.1
 forge_version = 47.1.79
 forge_kotlin_version = 3.9.1
 
-create_version = 0.5.1.d-9
-create_version_short = 0.5.1
+create_version = 6.0.0-85
+create_version_short = 6.0.0
+ponder_version = 1.0.52
 ktor_version = 2.3.0
 kotlin_json_version = 1.4.1
 kotlin_css_version = 1.0.0-pre.511

--- a/src/main/kotlin/littlechasiu/ctm/Extensions.kt
+++ b/src/main/kotlin/littlechasiu/ctm/Extensions.kt
@@ -6,8 +6,8 @@ import com.simibubi.create.content.trains.entity.TravellingPoint
 import com.simibubi.create.content.trains.graph.TrackEdge
 import com.simibubi.create.content.trains.graph.TrackNode
 import com.simibubi.create.content.trains.graph.TrackNodeLocation
-import com.simibubi.create.foundation.utility.Couple
 import littlechasiu.ctm.model.*
+import net.createmod.catnip.data.Couple
 import net.minecraft.resources.ResourceKey
 import net.minecraft.world.level.Level
 import net.minecraft.world.phys.Vec3


### PR DESCRIPTION
This PR fixes the dependencies and import statements so that the mod compiles with Create 6. I haven't _thoroughly_ tested this fix, but it compiles without issue and from my limited testing seems to work. I have tested up to the latest Create 6 version (6.0.4) although this updates the create dependency version to 6.0.0

Fixes #84 for Forge